### PR TITLE
fix(opentelemetry): Missing empty dict check in template

### DIFF
--- a/roles/opentelemetry/templates/opentelemetry_collector_helm_values.yml.j2
+++ b/roles/opentelemetry/templates/opentelemetry_collector_helm_values.yml.j2
@@ -41,7 +41,7 @@ collectors:
   {{ opentelemetry_collectors | ansible.builtin.to_nice_yaml | indent(2) }}
 {% endif %}
 
-{% if opentelemetry_additional_config is defined %}
+{% if opentelemetry_additional_config is defined and opentelemetry_additional_config | length > 0 %}
 {{ opentelemetry_additional_config | ansible.builtin.to_nice_yaml }}
 {% endif %}
 


### PR DESCRIPTION
## Proposed changes

Template miss a check to ensure opentelemetry_additional_config is not empty before trying to render it.

## Types of changes

What types of changes does your code introduce ?
- [X] Bugfix (non-breaking change which fixes an issue)

What part of the collection has been modified ?
_Please delete options that are not relevant and put an `x` in the boxes that apply_
- [X] Roles (add a role or upgrade an existing one)

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [X] I have labeled this PR
