### PR TITLE
Propagate role/phase tags through dynamic include_tasks

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "grafana"
+        - "install"
   when: grafana_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "grafana"
+        - "uninstall"
   when: not grafana_enabled
   tags: ["always"]

--- a/roles/jaeger/tasks/main.yml
+++ b/roles/jaeger/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "jaeger"
+        - "install"
   when: jaeger_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "jaeger"
+        - "uninstall"
   when: not jaeger_enabled
   tags: ["always"]

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "loki"
+        - "install"
   when: loki_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "loki"
+        - "uninstall"
   when: not loki_enabled
   tags: ["always"]

--- a/roles/opentelemetry/tasks/main.yml
+++ b/roles/opentelemetry/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "opentelemetry"
+        - "install"
   when: opentelemetry_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "opentelemetry"
+        - "uninstall"
   when: not opentelemetry_enabled
   tags: ["always"]

--- a/roles/victorialogs/tasks/main.yml
+++ b/roles/victorialogs/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "victorialogs"
+        - "install"
   when: victorialogs_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "victorialogs"
+        - "uninstall"
   when: not victorialogs_enabled
   tags: ["always"]

--- a/roles/victoriametrics/tasks/main.yml
+++ b/roles/victoriametrics/tasks/main.yml
@@ -2,11 +2,21 @@
 - name: "Include Single install enabled"
   ansible.builtin.include_tasks:
     file: "single.yml"
+    apply:
+      tags:
+        - "victoriametrics"
+        - "victoriametrics_single"
+        - "install"
   when: victoriametrics_single_enabled
   tags: ["always"]
 
 - name: "Include VMagent install enabled"
   ansible.builtin.include_tasks:
     file: "vmagent.yml"
+    apply:
+      tags:
+        - "victoriametrics"
+        - "victoriametrics_vmagent"
+        - "install"
   when: victoriametrics_vmagent_enabled
   tags: ["always"]

--- a/roles/vmoperator/tasks/main.yml
+++ b/roles/vmoperator/tasks/main.yml
@@ -1,44 +1,60 @@
 ---
-# import_tasks (static) plutôt que include_tasks : les tags des tâches
-# internes (namespace, preflight, helm_chart, custom_resource, secret) sont
-# ainsi sélectionnables via `--tags`, et le `when:` ci-dessous est propagé à
-# chaque tâche du fichier importé.
+# include_tasks dynamique en forme longue : `tags: ["always"]` sur l'include
+# garantit qu'il se déclenche toujours (le filtrage se fait sur les tâches
+# internes), et `apply.tags` ré-injecte les tags de rôle/phase dans chaque
+# tâche du fichier inclus pour que le ciblage par tag de rôle fonctionne.
+# Le `when:` gate le sous-fichier. Cohérent avec les autres rôles.
 - name: "Include VictoriaMetrics Operator install"
-  ansible.builtin.import_tasks: "operator.yml"
+  ansible.builtin.include_tasks:
+    file: "operator.yml"
+    apply:
+      tags:
+        - "vmoperator"
+        - "vmoperator_operator"
+        - "install"
   when: vmoperator_enabled
-  tags:
-    - "vmoperator"
-    - "vmoperator_operator"
-    - "install"
+  tags: ["always"]
 
 - name: "Include VMAlertmanager CR deployment"
-  ansible.builtin.import_tasks: "vmalertmanager.yml"
+  ansible.builtin.include_tasks:
+    file: "vmalertmanager.yml"
+    apply:
+      tags:
+        - "vmoperator"
+        - "vmoperator_vmalertmanager"
+        - "install"
   when: vmoperator_vmalertmanager_enabled
-  tags:
-    - "vmoperator"
-    - "vmoperator_vmalertmanager"
-    - "install"
+  tags: ["always"]
 
 - name: "Include VMAlert CR deployment"
-  ansible.builtin.import_tasks: "vmalert.yml"
+  ansible.builtin.include_tasks:
+    file: "vmalert.yml"
+    apply:
+      tags:
+        - "vmoperator"
+        - "vmoperator_vmalert"
+        - "install"
   when: vmoperator_vmalert_enabled
-  tags:
-    - "vmoperator"
-    - "vmoperator_vmalert"
-    - "install"
+  tags: ["always"]
 
 - name: "Include VMAuth CR + VMUsers deployment"
-  ansible.builtin.import_tasks: "vmauth.yml"
+  ansible.builtin.include_tasks:
+    file: "vmauth.yml"
+    apply:
+      tags:
+        - "vmoperator"
+        - "vmoperator_vmauth"
+        - "install"
   when: vmoperator_vmauth_enabled
-  tags:
-    - "vmoperator"
-    - "vmoperator_vmauth"
-    - "install"
+  tags: ["always"]
 
 - name: "Include default rules (rules-only install of k8s-stack chart)"
-  ansible.builtin.import_tasks: "default_rules.yml"
+  ansible.builtin.include_tasks:
+    file: "default_rules.yml"
+    apply:
+      tags:
+        - "vmoperator"
+        - "vmoperator_default_rules"
+        - "install"
   when: vmoperator_default_rules_enabled
-  tags:
-    - "vmoperator"
-    - "vmoperator_default_rules"
-    - "install"
+  tags: ["always"]


### PR DESCRIPTION
## Proposed changes

Dynamic `include_tasks` do not propagate their tags to the included tasks, so
running with `--tags <role>` matched the include but **silently skipped** every
task inside `setup.yml` / `cleanup.yml` (role reported `ok=2 changed=0` while
doing nothing). Full plays were never affected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Fixes # (issue)

What part of the collection has been modified ?
- [x] Roles (add a role or upgrade an existing one)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [X] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules
